### PR TITLE
Update license.csv

### DIFF
--- a/codelists/open/license.csv
+++ b/codelists/open/license.csv
@@ -1,21 +1,10 @@
-Code,Title,Source,OpenDefinitionCategory,Domain,Comments
-CC0-1.0,Creative Commons CCZero,https://creativecommons.org/publicdomain/zero/1.0/,"Content,data",Recommended conformant licenses,Dedicate to the Public Domain (all rights waived) 
-PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/,"Data",Recommended conformant licenses,Dedicate to the Public Domain (all rights waived) 
-CC-BY-4.0,Creative Commons Attribution 4.0,https://creativecommons.org/licenses/by/4.0/,"Content,data",Recommended conformant licenses,
-ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,"Data",Recommended conformant licenses,Attribution for data(bases) 
-CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommons.org/licenses/by-sa/4.0/,"Content,data",Recommended conformant licenses
-ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,"Data",Recommended conformant licenses,Attribution-ShareAlike for data(bases) 
-missing SPDX ID,Data licence Germany – attribution – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors.
-missing SPDX ID,Data licence Germany – Zero – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors.
-missing SPDX ID,Design Science License,URL,Content,Other conformant licenses,Little used. Incompatible with any other license.
-LAL-1.2,Free Art License 1.2,URL,Content,Other conformant licenses,
-LAL-1.3,Free Art License 1.3,URL,Content,Other conformant licenses,
-GFDL-1.1,"GNU Free Documentation License 1.1",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
-GFDL-1.2,"GNU Free Documentation License 1.2",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
-GFDL-1.3,"GNU Free Documentation License 1.3",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
-MirOS,MirOS License,URL,"Code,Content",Other conformant licenses,Little used.
-OGL-Canada-2.0,Open Government Licence Canada 2.0,URL,"Content, Data",Other conformant licenses,"Non-reusable. For use by the Canadian Federal government. Note version 1.0 is not approved as conformant. Note several Canadian provinces and municipalities have developed non-reusable licenses, each with differences from the federal OGL Canada. Some of these are open, as noted on a dedicated page."
-OGDL-Taiwan-1.0,Open Government Data License Taiwan 1.0,URL,Data,Other conformant licenses,"Non-reusable. For use by public sector licensors, governed by Taiwan law."
-OGL-UK-2.0,Open Government Licence United Kingdom 2.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-2.0 material may be released under CC-BY or ODC-BY.
-OGL-UK-3.0,Open Government Licence United Kingdom 3.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-3.0 material may be released under CC-BY or ODC-BY.
-O-UDA-1.0,Open Use of Data Agreement 1.0,URL,Data,Other conformant licenses,Little used.
+Code,Title,Source,OpenDefinitionCategory,Domain
+CC0-1.0,Creative Commons CCZero,https://creativecommons.org/publicdomain/zero/1.0/,"Content,data",Open Definition recommended conformant license
+CC-BY-4.0,Creative Commons Attribution 4.0,https://creativecommons.org/licenses/by/4.0/,"Content,data",Open Definition recommended conformant license
+CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommons.org/licenses/by-sa/4.0/,"Content,data",Open Definition recommended conformant license
+CC-BY-NC-SA-4.0,Creative Commons Attribution-NonCommercial-Share-Alike 4.0,https://creativecommons.org/licenses/by-nc-sa/4.0/,"Content,data",
+CC BY-ND 4.0,Creative Commons Attribution-NoDerivatives 4.0 International,https://creativecommons.org/licenses/by-nd/4.0/,"Content,data",
+CC BY-NC-ND 4.0,Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International,https://creativecommons.org/licenses/by-nc-nd/4.0/,"Content,data",
+ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,"Data",Open Definition recommended conformant license
+ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,"Data",Open Definition recommended conformant license
+PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/,"Data",Open Definition recommended conformant license

--- a/codelists/open/license.csv
+++ b/codelists/open/license.csv
@@ -1,7 +1,26 @@
-Code,Title,Source
-CC0-1.0,Creative Commons CCZero,https://creativecommons.org/publicdomain/zero/1.0/
-PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/
-CC-BY-4.0,Creative Commons Attribution 4.0,https://creativecommons.org/licenses/by/4.0/
-ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/
-CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommons.org/licenses/by-sa/4.0/
-ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/
+Code,Title,Source,OpenDefinitionCategory,Domain,Comments
+CC0-1.0,Creative Commons CCZero,https://creativecommons.org/publicdomain/zero/1.0/,"Content,data",Recommended conformant licenses,Dedicate to the Public Domain (all rights waived) 
+PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/,"Data",Recommended conformant licenses,Dedicate to the Public Domain (all rights waived) 
+CC-BY-4.0,Creative Commons Attribution 4.0,https://creativecommons.org/licenses/by/4.0/,"Content,data",Recommended conformant licenses,
+ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,"Data",Recommended conformant licenses,Attribution for data(bases) 
+CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommons.org/licenses/by-sa/4.0/,"Content,data",Recommended conformant licenses
+ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,"Data",Recommended conformant licenses,Attribution-ShareAlike for data(bases) 
+CC-BY-{version},Creative Commons Attribution 1.0-3.0,https://opendefinition.org/licenses/cc-by,Other conformant licenses,Content,"Includes all jurisdiction "ports"; Superseded by CC-BY-4.0."
+CC-BY-SA-{version},Creative Commons Attribution-ShareAlike 1.0-3.0,URL,Content,Other conformant licenses,"Includes all jurisdiction "ports"; Superseded by CC-BY-SA-4.0. Additionally, CC-BY-SA-1.0 is Incompatible with any other license."
+missing SPDX ID,Data licence Germany – attribution – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors. Note version 1.0 is not approved as conformant.
+missing SPDX ID,Data licence Germany – Zero – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors. Note there is no previous version.
+missing SPDX ID,Design Science License,URL,Content,Other conformant licenses,Little used. Incompatible with any other license.
+missing SPDX ID,EFF Open Audio License,URL,Content,Other conformant licenses,Deprecated in favor of CC-BY-SA.
+LAL-{version},Free Art License 1.2 and 1.3,URL,Content,Other conformant licenses,
+GFDL-{version},"GNU Free Documentation License 1.1, 1.2, and 1.3",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
+MirOS,MirOS License,URL,"Code,Content",Other conformant licenses,Little used.
+OGL-Canada-2.0,Open Government Licence Canada 2.0,URL,"Content, Data",Other conformant licenses,"Non-reusable. For use by the Canadian Federal government. Note version 1.0 is not approved as conformant. Note several Canadian provinces and municipalities have developed non-reusable licenses, each with differences from the federal OGL Canada. Some of these are open, as noted on a dedicated page."
+OGDL-Taiwan-1.0,Open Government Data License Taiwan 1.0,URL,Data,Other conformant licenses,"Non-reusable. For use by public sector licensors, governed by Taiwan law."
+OGL-UK-{version},Open Government Licence United Kingdom 2.0 and 3.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-2.0 and OGL-UK-3.0 material may be released under CC-BY or ODC-BY. Note version 1.0 is not approved as conformant.
+O-UDA-1.0,Open Use of Data Agreement 1.0,URL,Data,Other conformant licenses,Little used.
+missing SPDX ID,Talis Community License,URL,Data,Other conformant licenses,"Draft only, Deprecated in favour of ODC licenses."
+
+
+
+
+

--- a/codelists/open/license.csv
+++ b/codelists/open/license.csv
@@ -5,22 +5,17 @@ CC-BY-4.0,Creative Commons Attribution 4.0,https://creativecommons.org/licenses/
 ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,"Data",Recommended conformant licenses,Attribution for data(bases) 
 CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommons.org/licenses/by-sa/4.0/,"Content,data",Recommended conformant licenses
 ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,"Data",Recommended conformant licenses,Attribution-ShareAlike for data(bases) 
-CC-BY-{version},Creative Commons Attribution 1.0-3.0,https://opendefinition.org/licenses/cc-by,Other conformant licenses,Content,"Includes all jurisdiction "ports"; Superseded by CC-BY-4.0."
-CC-BY-SA-{version},Creative Commons Attribution-ShareAlike 1.0-3.0,URL,Content,Other conformant licenses,"Includes all jurisdiction "ports"; Superseded by CC-BY-SA-4.0. Additionally, CC-BY-SA-1.0 is Incompatible with any other license."
-missing SPDX ID,Data licence Germany – attribution – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors. Note version 1.0 is not approved as conformant.
-missing SPDX ID,Data licence Germany – Zero – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors. Note there is no previous version.
+missing SPDX ID,Data licence Germany – attribution – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors.
+missing SPDX ID,Data licence Germany – Zero – version 2.0,URL,Data,Other conformant licenses,Non-reusable. For use by Germany government licensors.
 missing SPDX ID,Design Science License,URL,Content,Other conformant licenses,Little used. Incompatible with any other license.
-missing SPDX ID,EFF Open Audio License,URL,Content,Other conformant licenses,Deprecated in favor of CC-BY-SA.
-LAL-{version},Free Art License 1.2 and 1.3,URL,Content,Other conformant licenses,
-GFDL-{version},"GNU Free Documentation License 1.1, 1.2, and 1.3",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
+LAL-1.2,Free Art License 1.2,URL,Content,Other conformant licenses,
+LAL-1.3,Free Art License 1.3,URL,Content,Other conformant licenses,
+GFDL-1.1,"GNU Free Documentation License 1.1",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
+GFDL-1.2,"GNU Free Documentation License 1.2",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
+GFDL-1.3,"GNU Free Documentation License 1.3",URL,Content,Other conformant licenses,Incompatible with any other license. Only conformant if used with no cover texts and no invariant sections.
 MirOS,MirOS License,URL,"Code,Content",Other conformant licenses,Little used.
 OGL-Canada-2.0,Open Government Licence Canada 2.0,URL,"Content, Data",Other conformant licenses,"Non-reusable. For use by the Canadian Federal government. Note version 1.0 is not approved as conformant. Note several Canadian provinces and municipalities have developed non-reusable licenses, each with differences from the federal OGL Canada. Some of these are open, as noted on a dedicated page."
 OGDL-Taiwan-1.0,Open Government Data License Taiwan 1.0,URL,Data,Other conformant licenses,"Non-reusable. For use by public sector licensors, governed by Taiwan law."
-OGL-UK-{version},Open Government Licence United Kingdom 2.0 and 3.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-2.0 and OGL-UK-3.0 material may be released under CC-BY or ODC-BY. Note version 1.0 is not approved as conformant.
+OGL-UK-2.0,Open Government Licence United Kingdom 2.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-2.0 material may be released under CC-BY or ODC-BY.
+OGL-UK-3.0,Open Government Licence United Kingdom 3.0,URL,"Content, Data",Other conformant licenses,Non-reusable. For use by UK government licensors; re-uses of OGL-UK-3.0 material may be released under CC-BY or ODC-BY.
 O-UDA-1.0,Open Use of Data Agreement 1.0,URL,Data,Other conformant licenses,Little used.
-missing SPDX ID,Talis Community License,URL,Data,Other conformant licenses,"Draft only, Deprecated in favour of ODC licenses."
-
-
-
-
-

--- a/codelists/open/license.csv
+++ b/codelists/open/license.csv
@@ -5,6 +5,6 @@ CC-BY-SA-4.0,Creative Commons Attribution Share-Alike 4.0,https://creativecommon
 CC-BY-NC-SA-4.0,Creative Commons Attribution-NonCommercial-Share-Alike 4.0,https://creativecommons.org/licenses/by-nc-sa/4.0/,"Content,data",
 CC BY-ND 4.0,Creative Commons Attribution-NoDerivatives 4.0 International,https://creativecommons.org/licenses/by-nd/4.0/,"Content,data",
 CC BY-NC-ND 4.0,Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International,https://creativecommons.org/licenses/by-nc-nd/4.0/,"Content,data",
-ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,"Data",Open Definition recommended conformant license
-ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,"Data",Open Definition recommended conformant license
-PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/,"Data",Open Definition recommended conformant license
+ODbL-1.0,Open Data Commons Open Database License,https://opendatacommons.org/licenses/odbl/summary/,Data,Open Definition recommended conformant license
+ODC-By-1.0,Open Data Commons Attribution License,https://opendatacommons.org/licenses/by/1-0/,Data,Open Definition recommended conformant license
+PDDL-1.0,Open Data Commons Public Domain Dedication and License,http://opendatacommons.org/licenses/pddl/1.0/,Data,Open Definition recommended conformant license

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -50,7 +50,7 @@ This page lists changes to the Risk Data Library Standard.
   - Replace `loss` object with `Loss` definition.
   - Removes `time_start`, `time_end`, `time_year` from `loss`.
   - Removes `loss_loss_type`, `loss_metric` from `$defs`.
-- [#127](https://github.com/GFDRR/rdl-standard/pull/127) - Inline `Exposure`, `Hazard_metadata`, `vulnerability`, `Vulnerability_function`, `Fragility_function`, `Occurence`, `Damage_to_loss_function`, `Engineering_demand_function`, `Probability`, `Empirical`, `Deterministic` and `Loss` and rearrange `$defs`
+- [#127](https://github.com/GFDRR/rdl-standard/pull/127) - Inline `Exposure`, `Hazard_metadata`, `vulnerability`, `Vulnerability_function`, `Fragility_function`, `Occurrence`, `Damage_to_loss_function`, `Engineering_demand_function`, `Probability`, `Empirical`, `Deterministic` and `Loss` and rearrange `$defs`
 
 ### Codelists
 
@@ -61,6 +61,7 @@ This page lists changes to the Risk Data Library Standard.
 - [#121](https://github.com/GFDRR/rdl-standard/pull/121) - Create 'frequency_distribution.csv' and 'seasonality.csv'
 - [#130](https://github.com/GFDRR/rdl-standard/pull/130) - 'hazard_type.csv' add descriptions and hazard category which aligns with UNDRR Hazard taxonomy, and update codes from abbreviations to human-readable words.
 - [#134](https://github.com/GFDRR/rdl-standard/pull/134) - 'risk_data_type.csv', replace codes with lower-case versions.
+- [#143](https://github.com/GFDRR/rdl-standard/pull/143) - Update 'license.csv' to include Open Definition conformant licences and those listed as options on WB Data Catalog.
 
 ### Normative documentation
 


### PR DESCRIPTION
Updating license.csv to include more licenses.

Initial proposal: is what the table would look like with 'other conformant licences' added to the recommended conformant licences, which were already included from https://opendefinition.org/licenses/ per #123 
I question the value of including the several deprecated licences.
Your views in terms of practicality - @pzwsk @matamadio ?
Best practice considerations - @odscjen @odscrachel @duncandewhurst ? 

Update: decision to include only OD conformant licences and those listed by WB Data Catalog.


**Related issues**

#123 

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))
- [ ] Run `./manage.py` pre-commit
