### PR TITLE
docs/reference/schema.md: Update hazard reference table

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -69,6 +69,7 @@ This page lists changes to the Risk Data Library Standard.
   - Use jsonschema Sphinx directive to generate schema reference tables from schema.
   - Restructure reference documentation.
   - Update `manage.py pre-commmit` to generate sub-schema reference.
+- [#169](https://github.com/GFDRR/rdl-standard/pull/169) - Uncollapse `event_sets` in `hazard` reference table.
 
 ### Non-normative documentation
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -151,7 +151,7 @@ The hazard dataset could include one or more footprints for the same event, wher
 ```{jsonschema} ../../docs/_readthedocs/html/rdl_schema_0.1.json
 ---
 pointer: /anyOf/0/properties/hazard
-collapse: event_sets
+collapse: event_sets/0/hazards,event_sets/0/spatial,event_sets/0/temporal,event_sets/0/events
 addtargets:
 ---
 ```


### PR DESCRIPTION
**Related issues**

Closes #162

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))
- [x] Run `./manage.py` pre-commit

If you added or removed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
