### PR TITLE
Update index.md separate reference and guidance

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,20 +1,26 @@
-<!-- https://hackmd.io/bdFuvXOfTXWzyHS44r1VXQ?both -->
-
 # Risk Data Library Standard
 
-The **Risk Data Library Standard (RDLS)** is an open data standard to make it easier to work with disaster and climate risk data. It provides a common description of the data used and produced in risk assessments, including **hazard**, **exposure**, **vulnerability**, and **modelled loss or impact**, data.
+The **Risk Data Library Standard (RDLS) is an open metadata standard** to describe datasets used in climate and disaster risk assessments. 
 
-The Risk Data Library (RDL) project grew out of in-depth community consultation on improving access to **risk information** and is a result of the collective effort and ongoing support of internationally-recognised research institutions and established global partnerships with combined expertise across multiple hazards and all aspects of risk assessment. Its overarching purpose is to support disaster resilience work by making risk data better and easier to work with.
+The overarching purpose of RDLS is to support climate and disaster risk reduction and resilience building by making risk data better and easier to work with.
 
-The RDLS gives risk experts a single language to describe hazard, exposure, vulnerability and modelled loss datasets. It gives datasets an underlying consistency that makes them highly interoperable and easily read by both people and machines. The schema contains labels for key metadata fields, making it easier to identify datasets hosted in different online catalogs without relying on external files or descriptions.
+The RDLS is designed to make it easier to work with disaster and climate risk data by providing a common description of **hazard**, **exposure**, **vulnerability**, and **modelled loss or impact** data.
 
-The RDLS has been developed by World Bank GFDRR for disaster and climate risk assessments but is intended to be used by anyone involved in generating or using disaster risk information.
+The standard originated from an in-depth consultation with the disaster and climate risk modeling community on improving access to **risk information**. It is the result of collective effort and ongoing support of internationally-recognised research institutions and established global partnerships with combined expertise across multiple hazards and all aspects of risk assessment. 
 
-This documentation provides a technical overview of the RDLS and its different elements:
+The RDLS gives risk experts a single language to describe the contents of risk datasets, providing the consistency that makes them highly interoperable, easily read by both people and machines and easier to identify datasets hosted in different online catalogs.
+
+The RDLS is curated by the Global Facility for Disaster Reduction and Recovery (GFDRR) and is intended for use by anyone involved in generating or using disaster risk information, and is open to community contributions to improve the standard.
+
+This documentation provides a technical overview of the RDLS including the data model and taxonomies used in the RDLS:
 
 - [Overview](rdl/index.md): The core standards used within the RDLS, use cases and a roadmap
-- [Reference](reference/index.md): how to organize and link the data using the RDLS schema
+- [Data model](data_model/index.md): how to organize and link the data using the RDLS schema
 - [Taxonomy](taxonomies/index.md): details of taxonomies adopted by the RDLS
+
+
+The documentation also provides guidance on how to implement the RDLS for your own datasets or data catalog, including creating JSON metadata files, packaging data and recommended formats for risk data:
+
 - [Guides](guides/index.md): how to implement the RDLS in your project
 - [About](about/index.md): other information on the roadmap, history, governance and license
 
@@ -26,9 +32,11 @@ The RDL is a collaborative project managed by the [Global Facility for Disaster 
    :hidden:
 
    rdl/index
-   reference/index
+   data_model/index
    taxonomies/index
    guides/index
    glossary
    about/index
 ```
+
+


### PR DESCRIPTION
Updates to make clear RDLS is for metadata.
Includes text change and adding separation of guidance from reference in the bullet list. No change made to TOC

**Related issues**

Partially addresses #160 - decision made in tooling session to keep public guidance but more clearly separate reference section from guidance.  


**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [ ] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))
- [ ] Run `./manage.py` pre-commit

If you added or removed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
