### PR TITLE
hazard_id, exposure_id, vulnerability_id removed from loss required a…

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -72,6 +72,7 @@ This page lists changes to the Risk Data Library Standard.
   - update `coordinates` to allow only numbers within arrays.
 - [#208](https://github.com/GFDRR/rdl-standard/pull/208) - Add regex pattern to `coordinate_system` and update description to mandate ESRI or EPSG codes.
 - [#205](https://github.com/GFDRR/rdl-standard/pull/205) - Convert `risk_data_type` to array.
+- [#215](https://github.com/GFDRR/rdl-standard/pull/219) - Remove `.hazard_id`, `exposure_id` and `vulnerability_id` from `loss` required array.
 
 ### Codelists
 

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -610,10 +610,7 @@
       "description": "Metadata that is specific to datasets that describe the losses associated with people, infrastructure, housing, production capacities and other tangible human assets due to the occurrence of one or more hazards.",
       "required": [
         "hazard_type",
-        "cost",
-        "hazard_id",
-        "exposure_id",
-        "vulnerability_id"
+        "cost"
       ],
       "properties": {
         "hazard_type": {


### PR DESCRIPTION
…rray

**Related issues**

closes #215 

**Description**

<!-- If the changes in the PR are not sufficiently explained by the related issues and commit messages, add a description here. -->

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))
- [x] Run `./manage.py` pre-commit

If you added or removed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
