### PR TITLE
schema/rdls_package_schema.json: Fix property name

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -61,7 +61,7 @@ This page lists changes to the Risk Data Library Standard.
   - Required fields in `Event_set`, `Hazard` and `Footprint`
   - Markdown syntax in `Attribution.role` description
 - [#190](https://github.com/GFDRR/rdl-standard/pull/190) - Deletes type key from properties with `$ref` components.
-- [#203](https://github.com/GFDRR/rdl-standard/pull/203) - Add package schema.
+- [#203](https://github.com/GFDRR/rdl-standard/pull/203), [#228](https://github.com/GFDRR/rdl-standard/pull/228) - Add package schema.
 - [#204](https://github.com/GFDRR/rdl-standard/pull/204):
   - Add field `metrics`.
   - rename cost_type.csv to metric_dimension.csv and update code descriptions.

--- a/schema/rdls_package_schema.json
+++ b/schema/rdls_package_schema.json
@@ -8,7 +8,7 @@
     "datasets"
   ],
   "properties": {
-    "networks": {
+    "datasets": {
       "title": "Datasets",
       "description": "RDLS metadata describing one or more datasets.",
       "type": "array",


### PR DESCRIPTION
**Related issues**

* Related to https://github.com/GFDRR/rdl-standard/issues/200

**Description**

This PR fixes an incorrect name in the package schema.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))
- [ ] Run `./manage.py` pre-commit

If you added or removed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
