### PR TITLE
rdls_schema: Fix codelist links

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -81,7 +81,7 @@ This page lists changes to the Risk Data Library Standard.
 - [#232](https://github.com/GFDRR/rdl-standard/pull/232)
   - Convert `disaster_identifiers` to array of `Classification` objects.
   - Add new codes to classification_scheme.csv.
-- [#236](https://github.com/GFDRR/rdl-standard/pull/236) - Fix broken codelist reference URLs.
+- [#236](https://github.com/GFDRR/rdl-standard/pull/236), [#244](https://github.com/GFDRR/rdl-standard/pull/244) - Fix broken codelist reference URLs.
 - [#239](https://github.com/GFDRR/rdl-standard/pull/239) - Clarify purpose of `links`, add link to dataset identifier guidance in `id` description.
 - [#241](https://github.com/GFDRR/rdl-standard/pull/241) - Update schema and documentation URLs.
 - [#242](https://github.com/GFDRR/rdl-standard/pull/242) - Remove redundant `minProperties` keywords, add missing `minLength` and `uniqueItems` keywords.

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -230,7 +230,7 @@
         "hazard_primary": {
           "title": "Primary hazard type",
           "type": "string",
-          "description": "The primary hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_type).",
+          "description": "The primary hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_type).",
           "codelist": "hazard_type.csv",
           "openCodelist": false,
           "enum": [
@@ -250,7 +250,7 @@
         "hazard_secondary": {
           "title": "Secondary hazard type",
           "type": "string",
-          "description": "The secondary hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_type).",
+          "description": "The secondary hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_type).",
           "codelist": "hazard_type.csv",
           "openCodelist": false,
           "enum": [
@@ -270,7 +270,7 @@
         "hazard_process_primary": {
           "title": "Primary hazard process",
           "type": "string",
-          "description": "The primary hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_process_type).",
+          "description": "The primary hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_process_type).",
           "codelist": "process_type.csv",
           "openCodelist": false,
           "enum": [
@@ -309,7 +309,7 @@
         "hazard_process_secondary": {
           "title": "Secondary hazard process",
           "type": "string",
-          "description": "The secondary hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_process_type).",
+          "description": "The secondary hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_process_type).",
           "codelist": "process_type.csv",
           "openCodelist": false,
           "enum": [
@@ -348,7 +348,7 @@
         "hazard_analysis_type": {
           "title": "Hazard analysis type",
           "type": "string",
-          "description": "The type of analysis applied to the hazard data used in the modelled scenario(s), from the closed [analysis type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#analysis_type).",
+          "description": "The type of analysis applied to the hazard data used in the modelled scenario(s), from the closed [analysis type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#analysis_type).",
           "codelist": "analysis_type.csv",
           "openCodelist": false,
           "enum": [
@@ -359,7 +359,7 @@
         },
         "intensity": {
           "title": "Hazard intensity measurement",
-          "description": "The metric and units the hazard intensity measurement is given in, from the open [intensity measure codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#IMT).",
+          "description": "The metric and units the hazard intensity measurement is given in, from the open [intensity measure codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#IMT).",
           "type": "string",
           "codelist": "IMT.csv",
           "openCodelist": true,
@@ -627,7 +627,7 @@
         "hazard_type": {
           "title": "Hazard type",
           "type": "string",
-          "description": "The main type of hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_type).",
+          "description": "The main type of hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_type).",
           "codelist": "hazard_type.csv",
           "openCodelist": false,
           "enum": [
@@ -647,7 +647,7 @@
         "hazard_process": {
           "title": "Hazard process",
           "type": "string",
-          "description": "The main hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_process_type).",
+          "description": "The main hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#hazard_process_type).",
           "codelist": "process_type.csv",
           "openCodelist": false,
           "enum": [
@@ -1115,7 +1115,7 @@
         "countries": {
           "title": "Countries",
           "type": "array",
-          "description": "The countries covered by the geographical area, from the closed [country codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#country).",
+          "description": "The countries covered by the geographical area, from the closed [country codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#country).",
           "items": {
             "type": "string",
             "enum": [
@@ -1413,7 +1413,7 @@
         "scale": {
           "title": "Spatial scale",
           "type": "string",
-          "description": "The spatial scale of the geographical area, from the closed [spatial scale codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#spatial_scale).",
+          "description": "The spatial scale of the geographical area, from the closed [spatial scale codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#spatial_scale).",
           "codelist": "spatial_scale.csv",
           "openCodelist": false,
           "enum": [
@@ -1443,7 +1443,7 @@
         "scheme": {
           "title": "Scheme",
           "type": "string",
-          "description": "The gazetteer from which the entry is drawn, from the open [location gazetteers codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#location_gazetteers).",
+          "description": "The gazetteer from which the entry is drawn, from the open [location gazetteers codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#location_gazetteers).",
           "codelist": "location_gazetteers.csv",
           "openCodelist": true,
           "minLength": 1
@@ -1471,7 +1471,7 @@
         "type": {
           "title": "Type",
           "type": "string",
-          "description": "The GeoJSON geometry type that is described by `.coordinates`, from the closed [geometry_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#geometry_type).",
+          "description": "The GeoJSON geometry type that is described by `.coordinates`, from the closed [geometry_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#geometry_type).",
           "codelist": "geometry_type.csv",
           "openCodelist": false,
           "enum": [
@@ -1554,7 +1554,7 @@
         },
         "processes": {
           "title": "Hazard processes",
-          "description": "The hazard process types for this hazard, from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#process_type).",
+          "description": "The hazard process types for this hazard, from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#process_type).",
           "type": "array",
           "items": {
             "type": "string",
@@ -1598,7 +1598,7 @@
         },
         "intensity_measure": {
           "title": "Intensity measure",
-          "description": "The metric and unit in which the intensity of this hazard is measured, from the open [intensity measure codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#IMT).",
+          "description": "The metric and unit in which the intensity of this hazard is measured, from the open [intensity measure codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#IMT).",
           "type": "string",
           "codelist": "IMT.csv",
           "openCodelist": true,
@@ -1639,7 +1639,7 @@
         },
         "processes": {
           "title": "Hazard processes",
-          "description": "The hazard process types for this hazard, from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#process_type).",
+          "description": "The hazard process types for this hazard, from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists#process_type).",
           "type": "array",
           "items": {
             "type": "string",


### PR DESCRIPTION
**Related issues**

From https://github.com/GFDRR/rdl-standard/issues/135#issuecomment-1708682870

**Description**

This PR fixes codelist links in the schema that were working in the schema browser, but not in the schema reference tables.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

If you added, removed or renamed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`
- [ ] Update the diagrams in `reference/schema/md`
- [ ] Update the JSON files in `examples`

Always:

- [x] Run `./manage.py` pre-commit
- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
