### PR TITLE
Loss updates

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -85,6 +85,9 @@ This page lists changes to the Risk Data Library Standard.
 - [#239](https://github.com/GFDRR/rdl-standard/pull/239) - Clarify purpose of `links`, add link to dataset identifier guidance in `id` description.
 - [#241](https://github.com/GFDRR/rdl-standard/pull/241) - Update schema and documentation URLs.
 - [#242](https://github.com/GFDRR/rdl-standard/pull/242) - Remove redundant `minProperties` keywords, add missing `minLength` and `uniqueItems` keywords.
+- [#246](https://github.com/GFDRR/rdl-standard/pull/246) - Update `loss` component:
+  - Replace `loss` object with `loss.losses` array.
+  - Replace `loss.costs` array with `loss.losses.cost` object.
 
 ### Codelists
 

--- a/docs/reference/codelists.md
+++ b/docs/reference/codelists.md
@@ -237,8 +237,8 @@ This codelist has the following codes:
 This codelist is referenced by the following properties:
 
 - [`vulnerability/hazard_analysis_type`](rdls_schema.json,/properties/vulnerability,hazard_analysis_type)
-- [`loss/hazard_analysis_type`](rdls_schema.json,/properties/loss,hazard_analysis_type)
 - [`Event_set/analysis_type`](rdls_schema.json,/$defs/Event_set,analysis_type)
+- [`Losses/hazard_analysis_type`](rdls_schema.json,/$defs/Losses,hazard_analysis_type)
 
 This codelist has the following codes:
 
@@ -312,7 +312,7 @@ This codelist is referenced by the following properties:
 
 - [`exposure/category`](rdls_schema.json,/properties/exposure,category)
 - [`vulnerability/category`](rdls_schema.json,/properties/vulnerability,category)
-- [`loss/category`](rdls_schema.json,/properties/loss,category)
+- [`Losses/category`](rdls_schema.json,/$defs/Losses,category)
 
 This codelist has the following codes:
 
@@ -354,7 +354,7 @@ This codelist is referenced by the following properties:
 - [`vulnerability/functions/fragility/approach`](rdls_schema.json,/properties/vulnerability,functions/fragility/approach)
 - [`vulnerability/functions/damage_to_loss/approach`](rdls_schema.json,/properties/vulnerability,functions/damage_to_loss/approach)
 - [`vulnerability/functions/engineering_demand/approach`](rdls_schema.json,/properties/vulnerability,functions/engineering_demand/approach)
-- [`loss/approach`](rdls_schema.json,/properties/loss,approach)
+- [`Losses/approach`](rdls_schema.json,/$defs/Losses,approach)
 
 This codelist has the following codes:
 
@@ -398,9 +398,9 @@ This codelist is referenced by the following properties:
 
 - [`vulnerability/hazard_primary`](rdls_schema.json,/properties/vulnerability,hazard_primary)
 - [`vulnerability/hazard_secondary`](rdls_schema.json,/properties/vulnerability,hazard_secondary)
-- [`loss/hazard_type`](rdls_schema.json,/properties/loss,hazard_type)
 - [`Hazard/type`](rdls_schema.json,/$defs/Hazard,type)
 - [`Trigger/type`](rdls_schema.json,/$defs/Trigger,type)
+- [`Losses/hazard_type`](rdls_schema.json,/$defs/Losses,hazard_type)
 
 This codelist has the following codes:
 
@@ -435,7 +435,7 @@ open:
 
 This codelist is referenced by the following properties:
 
-- [`loss/type`](rdls_schema.json,/properties/loss,type)
+- [`Losses/type`](rdls_schema.json,/$defs/Losses,type)
 
 This codelist has the following codes:
 
@@ -478,9 +478,9 @@ This codelist is referenced by the following properties:
 
 - [`vulnerability/hazard_process_primary`](rdls_schema.json,/properties/vulnerability,hazard_process_primary)
 - [`vulnerability/hazard_process_secondary`](rdls_schema.json,/properties/vulnerability,hazard_process_secondary)
-- [`loss/hazard_process`](rdls_schema.json,/properties/loss,hazard_process)
 - [`Hazard/processes`](rdls_schema.json,/$defs/Hazard,processes)
 - [`Trigger/processes`](rdls_schema.json,/$defs/Trigger,processes)
+- [`Losses/hazard_process`](rdls_schema.json,/$defs/Losses,hazard_process)
 
 This codelist has the following codes:
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1254,7 +1254,7 @@ Each `Losses` has the following fields:
 ```{jsonschema} ../../docs/_readthedocs/html/rdls_schema.json
 ---
 pointer: /$defs/Losses
-collapse: impact
+collapse: cost,impact
 addtargets:
 ---
 ```

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -714,7 +714,7 @@ jsonpointer: /properties/loss/description
 The loss component provides metadata describing data generated in risk assessments, i.e., modelled impacts and losses for single historical events or hypothetical scenarios and risk estimates from analysis of large event sets. The data can include monetary and non-monetary, and direct or indirect, impacts and losses.
 Loss datasets can be explicitly linked to the exposure, hazard, and vulnerability datasets used in the analysis. This component uses descriptions of assets, hazards and impact types consistent with all other components of this standard. Spatial reference and location information are described using existing external standards. Temporal information can include date and duration of events or year of scenario, and is defined using the Dublin Core standards.
 
-The following diagram shows key loss component fields, with required fields highlighted in blue:
+The following diagram shows key loss component fields, with required fields highlighted in blue.  The ![array](../img/array.png) icon indicates that a field is an array.
 
 ```{eval-rst}
 .. uml::
@@ -728,25 +728,29 @@ The following diagram shows key loss component fields, with required fields high
       BackGroundColor #239ce8
     }
   </style>
-  #highlight "hazard_type" <<required>>
-  #highlight "cost" <<required>>
-  #highlight "cost" / "type" <<required>>
-  #highlight "cost" / "unit" <<required>>
+  #highlight "losses" / "0" / "hazard_type" <<required>>
+  #highlight "losses" / "0" / "cost" <<required>>
+  #highlight "losses" / "0" / "cost" / "type" <<required>>
+  #highlight "losses" / "0" / "cost" / "unit" <<required>>
   {
-    "hazard_type": "",
-    "hazard_process": "",
-    "category": "",
-    "type": "",
-    "impact": {
-      "type": "",
-      "metric": "",
-      "unit": ""
-    },
-    "approach": "",
-    "cost": {
-      "type": "",
-      "unit": ""
-    }
+    "losses": [
+      {
+        "hazard_type": "",
+        "hazard_process": "",
+        "category": "",
+        "type": "",
+        "impact": {
+          "type": "",
+          "metric": "",
+          "unit": ""
+        },
+        "approach": "",
+        "cost": {
+          "type": "",
+          "unit": ""
+        }
+      }
+    ]
   }
   @endjson
 
@@ -757,7 +761,7 @@ The following table lists all loss component fields:
 ```{jsonschema} ../../docs/_readthedocs/html/rdls_schema.json
 ---
 pointer: /properties/loss
-collapse: cost,impact
+collapse: losses/0/cost,losses/0/impact
 addtargets:
 ---
 ```
@@ -1121,7 +1125,7 @@ jsonpointer: /$defs/Cost/description
 This sub-schema is referenced by the following properties:
 
 - [`vulnerability/cost`](rdls_schema.json,/properties/vulnerability,cost)
-- [`loss/cost`](rdls_schema.json,/properties/loss,cost)
+- [`Losses/cost`](rdls_schema.json,/$defs/Losses,cost)
 
 Each `Cost` has the following fields:
 
@@ -1170,7 +1174,7 @@ jsonpointer: /$defs/Impact/description
 This sub-schema is referenced by the following properties:
 
 - [`vulnerability/impact`](rdls_schema.json,/properties/vulnerability,impact)
-- [`loss/impact`](rdls_schema.json,/properties/loss,impact)
+- [`Losses/impact`](rdls_schema.json,/$defs/Losses,impact)
 
 Each `Impact` has the following fields:
 
@@ -1227,6 +1231,30 @@ Each `Link` has the following fields:
 ---
 pointer: /$defs/Link
 collapse:
+addtargets:
+---
+```
+
+### Losses
+
+`Losses` is defined as:
+
+```{jsoninclude-quote} ../../docs/_readthedocs/html/rdls_schema.json
+---
+jsonpointer: /$defs/Losses/description
+---
+```
+
+This sub-schema is referenced by the following properties:
+
+- [`loss/losses`](rdls_schema.json,/properties/loss,losses)
+
+Each `Losses` has the following fields:
+
+```{jsonschema} ../../docs/_readthedocs/html/rdls_schema.json
+---
+pointer: /$defs/Losses
+collapse: impact
 addtargets:
 ---
 ```

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -2433,13 +2433,8 @@
         },
         "cost": {
           "title": "Costs",
-          "type": "array",
           "description": "The costs associated with the losses.",
-          "items": {
-            "$ref": "#/$defs/Cost"
-          },
-          "minItems": 1,
-          "uniqueItems": true
+          "$ref": "#/$defs/Cost"
         },
         "impact": {
           "title": "Loss impact",

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -57,7 +57,7 @@
       "description": "The entity responsible for making the dataset available.",
       "$ref": "#/$defs/Entity"
     },
-    "version": {issue
+    "version": {
       "title": "Dataset version",
       "type": "string",
       "description": "The version indicator (name or identifier) of the dataset.",

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -618,163 +618,17 @@
     "loss": {
       "title": "Loss metadata",
       "type": "object",
-      "description": "Metadata that is specific to datasets that describe the losses associated with people, infrastructure, housing, production capacities and other tangible human assets due to the occurrence of one or more hazards.",
-      "required": [
-        "hazard_type",
-        "cost"
-      ],
+      "description": "Metadata that is specific to datasets that describe measures of impact in the form of damage or destruction caused by a disaster.",
       "properties": {
-        "hazard_type": {
-          "title": "Hazard type",
-          "type": "string",
-          "description": "The main type of hazard involved in the modelled scenario(s), from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_type).",
-          "codelist": "hazard_type.csv",
-          "openCodelist": false,
-          "enum": [
-            "coastal_flood",
-            "convective_storm",
-            "drought",
-            "earthquake",
-            "extreme_temperature",
-            "flood",
-            "landslide",
-            "tsunami",
-            "volcanic",
-            "wildfire",
-            "strong_wind"
-          ]
-        },
-        "hazard_process": {
-          "title": "Hazard process",
-          "type": "string",
-          "description": "The main hazard process involved in the modelled scenario(s), from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_process_type).",
-          "codelist": "process_type.csv",
-          "openCodelist": false,
-          "enum": [
-            "coastal_flood",
-            "storm_surge",
-            "tornado",
-            "agricultural_drought",
-            "hydrological_drought",
-            "meteorological_drought",
-            "socioeconomic_drought",
-            "primary_rupture",
-            "secondary_rupture",
-            "ground_motion",
-            "liquefaction",
-            "extreme_cold",
-            "extreme_heat",
-            "fluvial_flood",
-            "pluvial_flood",
-            "groundwater_flood",
-            "snow_avalanche",
-            "landslide_general",
-            "landslide_rockslide",
-            "landslide_mudflow",
-            "landslide_rockfall",
-            "tsunami",
-            "ashfall",
-            "volcano_ballistics",
-            "lahar",
-            "lava",
-            "pyroclastic_flow",
-            "wildfire",
-            "extratropical_cyclone",
-            "tropical_cyclone"
-          ]
-        },
-        "description": {
-          "title": "Loss description",
-          "type": "string",
-          "description": "Additional details of the dataset.",
-          "minLength": 1
-        },
-        "category": {
-          "title": "Exposure category",
-          "description": "The category of the exposed assets, from the closed [exposure_category codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#exposure-category).",
-          "type": "string",
-          "codelist": "exposure_category.csv",
-          "openCodelist": false,
-          "enum": [
-            "agriculture",
-            "buildings",
-            "infrastructure",
-            "population",
-            "natural_environment"
-          ]
-        },
-        "cost": {
-          "title": "Asset cost",
+        "losses": {
+          "title": "Losses",
           "type": "array",
-          "description": "The costs associated with the loss of specific elements of assets detailed in the dataset.",
+          "description": "Information about the losses described in the dataset.",
           "items": {
-            "$ref": "#/$defs/Cost"
+            "$ref": "#/$defs/Losses"
           },
           "minItems": 1,
           "uniqueItems": true
-        },
-        "impact": {
-          "title": "Loss impact",
-          "description": "The details of the loss impact values produced in the modelled scenario(s).",
-          "$ref": "#/$defs/Impact"
-        },
-        "type": {
-          "title": "Loss type",
-          "type": "string",
-          "description": "The type of loss described in the dataset, from the closed [loss_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#loss-type).",
-          "codelist": "loss_type.csv",
-          "openCodelist": false,
-          "enum": [
-            "ground_up",
-            "insured",
-            "gross",
-            "count",
-            "net_precat",
-            "net_postcat"
-          ]
-        },
-        "approach": {
-          "title": "Loss approach",
-          "type": "string",
-          "description": "The approach the loss calculation function is based upon, taken from the closed [function_approach codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#function-approach).",
-          "codelist": "function_approach.csv",
-          "openCodelist": false,
-          "enum": [
-            "analytical",
-            "empirical",
-            "hybrid",
-            "judgement"
-          ]
-        },
-        "hazard_analysis_type": {
-          "title": "Event frequency type",
-          "type": "string",
-          "description": "The type of occurrence frequency represented in the modelled scenario, from the closed [analysis_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#loss-type).",
-          "enum": [
-            "deterministic",
-            "empirical",
-            "probabilistic"
-          ],
-          "codelist": "analysis_type.csv",
-          "openCodelist": false
-        },
-        "hazard_id": {
-          "title": "Hazard dataset",
-          "type": "string",
-          "description": "A unique identifier for the hazard dataset used in the modelled scenario(s). Use of an HTTP URI is recommended.",
-          "minLength": 1
-        },
-        "exposure_id": {
-          "title": "Exposure dataset",
-          "type": "string",
-          "description": "A unique identifier for the exposure dataset used in the modelled scenario(s). Use of an HTTP URI is recommended.",
-          "minLength": 1
-        },
-        "vulnerability_id": {
-          "title": "Vulnerability dataset",
-          "type": "string",
-          "description": "A unique identifier for the vulnerability dataset used in the modelled scenario(s). Use of an HTTP URI is recommended.",
-          "minLength": 1
         }
       },
       "minProperties": 1
@@ -2480,6 +2334,177 @@
         "href",
         "rel"
       ],
+      "minProperties": 1
+    },
+    "Losses": {
+      "title": "Losses",
+      "type": "object",
+      "description": "Losses resulting from the occurrence of a hazard.",
+      "required": [
+        "id",
+        "hazard_type",
+        "cost"
+      ],
+      "properties": {
+        "id": {
+          "title": "Losses identifier",
+          "description": "A local identifier for the losses.",
+          "type": "string",
+          "minLength": 1
+        },
+        "hazard_type": {
+          "title": "Hazard type",
+          "type": "string",
+          "description": "The main type of hazard that resulted in the losses, from the closed [hazard type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_type).",
+          "codelist": "hazard_type.csv",
+          "openCodelist": false,
+          "enum": [
+            "coastal_flood",
+            "convective_storm",
+            "drought",
+            "earthquake",
+            "extreme_temperature",
+            "flood",
+            "landslide",
+            "tsunami",
+            "volcanic",
+            "wildfire",
+            "strong_wind"
+          ]
+        },
+        "hazard_process": {
+          "title": "Hazard process",
+          "type": "string",
+          "description": "The main hazard process that resulted in the losses, from the closed [hazard process type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists.html#hazard_process_type).",
+          "codelist": "process_type.csv",
+          "openCodelist": false,
+          "enum": [
+            "coastal_flood",
+            "storm_surge",
+            "tornado",
+            "agricultural_drought",
+            "hydrological_drought",
+            "meteorological_drought",
+            "socioeconomic_drought",
+            "primary_rupture",
+            "secondary_rupture",
+            "ground_motion",
+            "liquefaction",
+            "extreme_cold",
+            "extreme_heat",
+            "fluvial_flood",
+            "pluvial_flood",
+            "groundwater_flood",
+            "snow_avalanche",
+            "landslide_general",
+            "landslide_rockslide",
+            "landslide_mudflow",
+            "landslide_rockfall",
+            "tsunami",
+            "ashfall",
+            "volcano_ballistics",
+            "lahar",
+            "lava",
+            "pyroclastic_flow",
+            "wildfire",
+            "extratropical_cyclone",
+            "tropical_cyclone"
+          ]
+        },
+        "description": {
+          "title": "Loss description",
+          "type": "string",
+          "description": "Additional details of the losses.",
+          "minLength": 1
+        },
+        "category": {
+          "title": "Asset category",
+          "description": "The category of the lost assets, from the closed [exposure_category codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#exposure-category).",
+          "type": "string",
+          "codelist": "exposure_category.csv",
+          "openCodelist": false,
+          "enum": [
+            "agriculture",
+            "buildings",
+            "infrastructure",
+            "population",
+            "natural_environment"
+          ]
+        },
+        "cost": {
+          "title": "Costs",
+          "type": "array",
+          "description": "The costs associated with the losses.",
+          "items": {
+            "$ref": "#/$defs/Cost"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "impact": {
+          "title": "Loss impact",
+          "description": "Details of the way in which the loss impact was calculated and measured.",
+          "$ref": "#/$defs/Impact"
+        },
+        "type": {
+          "title": "Loss type",
+          "type": "string",
+          "description": "The type of losses, from the closed [loss_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#loss-type).",
+          "codelist": "loss_type.csv",
+          "openCodelist": false,
+          "enum": [
+            "ground_up",
+            "insured",
+            "gross",
+            "count",
+            "net_precat",
+            "net_postcat"
+          ]
+        },
+        "approach": {
+          "title": "Loss approach",
+          "type": "string",
+          "description": "The approach the loss calculation function is based upon, taken from the closed [function_approach codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#function-approach).",
+          "codelist": "function_approach.csv",
+          "openCodelist": false,
+          "enum": [
+            "analytical",
+            "empirical",
+            "hybrid",
+            "judgement"
+          ]
+        },
+        "hazard_analysis_type": {
+          "title": "Event frequency type",
+          "type": "string",
+          "description": "The type of occurrence frequency represented in the losses, from the closed [analysis_type codelist](https://docs.riskdatalibrary.org/en/{{version}}/reference/codelists/#loss-type).",
+          "enum": [
+            "deterministic",
+            "empirical",
+            "probabilistic"
+          ],
+          "codelist": "analysis_type.csv",
+          "openCodelist": false
+        },
+        "hazard_id": {
+          "title": "Hazard dataset",
+          "type": "string",
+          "description": "A unique identifier for the hazard dataset used in calculating the losses. Use of an HTTP URI is recommended.",
+          "minLength": 1
+        },
+        "exposure_id": {
+          "title": "Exposure dataset",
+          "type": "string",
+          "description": "A unique identifier for the exposure dataset used in calculating the losses. Use of an HTTP URI is recommended.",
+          "minLength": 1
+        },
+        "vulnerability_id": {
+          "title": "Vulnerability dataset",
+          "type": "string",
+          "description": "A unique identifier for the vulnerability dataset used in in calculating the losses. Use of an HTTP URI is recommended.",
+          "minLength": 1
+        }
+      },
       "minProperties": 1
     }
   },


### PR DESCRIPTION
**Related issues**

The changes in this PR were proposed in https://github.com/GFDRR/rdl-standard/issues/135#issuecomment-1708577671 and https://github.com/GFDRR/rdl-standard/issues/135#issuecomment-1708617812.

**Description**

* Replace `loss` object with `loss.losses` array
* Update field titles and descriptions to make sense in the context of an array
* Replace `loss.cost` array with `loss.losses.cost` object
* Update [loss diagram](https://docs.riskdatalibrary.org/en/loss-updates/reference/schema/#loss-metadata)

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

If you added, removed or renamed a field:

- [x] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`
- [x] Update the diagrams in `reference/schema/md`
- [ ] Update the JSON files in `examples`

Always:

- [x] Run `./manage.py` pre-commit
- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
