### PR TITLE
Update rdls_schema.json

### DIFF
--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -19,7 +19,7 @@
     "id": {
       "title": "Dataset identifier",
       "type": "string",
-      "description": "A unique identifier for the dataset. Use of an HTTP URI is recommended. For more information, see [how to assign a dataset identifier](https://rdl-standard.readthedocs.io/en/{{version}}/reference/codelists/#assign-a-dataset-identifier).",
+      "description": "A unique identifier for the dataset. Use of an HTTP URI is recommended. For more information, see [how to assign a dataset identifier](https://docs.riskdatalibrary.org/en/{{version}}/guides/metadata/#assign-a-dataset-identifier).",
       "minLength": 1
     },
     "title": {


### PR DESCRIPTION
Dataset Identifier URL pointing to readthedocs version of docs and codelists location, which does not give correct guidance. Replaced with correct location of guidance relevant to the field (how to complete dataset identifier)

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

If you added, removed or renamed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`
- [ ] Update the diagrams in `reference/schema/md`
- [ ] Update the JSON files in `examples`

Always:

- [ ] Run `./manage.py` pre-commit
- [ ] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
