### PR TITLE
Add risk index to impact metrics

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,6 +9,7 @@ This page lists changes to the Risk Data Library Standard.
 ### Codelists
 
 - [#370](https://github.com/GFDRR/rdl-standard/pull/370) - 'IMT.csv' Expanded list and updated structure.
+- [#381](https://github.com/GFDRR/rdl-standard/pull/381) - Add 'risk_index' to `impact_metric.csv`.
 
 ### Normative documentation
 

--- a/schema/codelists/open/impact_metric.csv
+++ b/schema/codelists/open/impact_metric.csv
@@ -19,3 +19,4 @@ at_risk_tail_value,Tail Value at Risk,Estimated losses at or exceeding a specifi
 downtime_loss,Downtime (loss),Duration of downtime (business or service interruption).,Loss
 asset_loss,Number of assets,"The estimated number of structures, or length of infrastructure, damaged.",Loss
 displaced_count,Number of people displaced,The estimated number of people displaced due to physical damage and disruption.,Loss
+risk_index,Risk Index,"A specified index or classification of risk levels, which may be numeric or non-numeric.",Loss 

--- a/schema/codelists/open/impact_metric.csv
+++ b/schema/codelists/open/impact_metric.csv
@@ -19,4 +19,4 @@ at_risk_tail_value,Tail Value at Risk,Estimated losses at or exceeding a specifi
 downtime_loss,Downtime (loss),Duration of downtime (business or service interruption).,Loss
 asset_loss,Number of assets,"The estimated number of structures, or length of infrastructure, damaged.",Loss
 displaced_count,Number of people displaced,The estimated number of people displaced due to physical damage and disruption.,Loss
-risk_index,Risk Index,"A specified index or classification of risk levels, which may be numeric or non-numeric.",Loss 
+risk_index,Risk Index,"A specified index or classification of risk levels, which may be numeric or non-numeric.",Loss


### PR DESCRIPTION
In response to https://github.com/GFDRR/rdl-standard/issues/375, I realised we didn't have an option to include risk index as a loss metric. Similar to assessments using a classified hazard index to describe hazard, some assessments also report risk as an index e.g. 'low to high' so we should allow for that.