### PR TITLE
manage.py: Add format-csv command

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -482,5 +482,20 @@ def update_codelists(ctx):
     ctx.invoke(update_media_type)
 
 
+@cli.command()
+@click.argument('filename', type=click.Path(exists=True))
+def format_csv(filename):
+    """
+    Format a CSV file to conform to the requirements of the tests.
+    """
+    with open(filename, 'r') as f:
+        reader = csv.reader(f)
+        data = list(reader)
+    
+    with open(filename, 'w') as f:
+        writer = csv.writer(f, lineterminator='\n')
+        writer.writerows(data)
+
+
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
Adds a `format-csv` command to `manage.py` to format CSVs when resolving "CSV is improperly formatted" test failures, e.g.

```bash
./manage.py format-csv schema/codelists/open/quantity_kind.csv
```

No changelog entry required as this is just a convenience for maintainers of the standard.

