### PR TITLE
Replace Multi-Hazard Index with Hazard Index

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -8,7 +8,7 @@ This page lists changes to the Risk Data Library Standard.
 
 ### Codelists
 
-- [#370](https://github.com/GFDRR/rdl-standard/pull/370) - 'IMT.csv' Expanded list and updated structure.
+- [#370](https://github.com/GFDRR/rdl-standard/pull/370), [#383](https://github.com/GFDRR/rdl-standard/pull/383) - 'IMT.csv' Expanded list and updated structure.
 
 ### Normative documentation
 

--- a/schema/codelists/open/IMT.csv
+++ b/schema/codelists/open/IMT.csv
@@ -105,5 +105,5 @@ BA:ha,Burned Area (ha),Surface area impacted by the hazard. Described in square 
 BA:km2,Burned Area (km²),Surface area impacted by the hazard. Described in square kilometers.,BA,km2,wildfire
 FWI:-,Fire Weather Index,Meteorological fire danger index.,FWI,-,wildfire
 riskidx:-,Risk score,Composite risk quantification.,riskidx,-,universal
-MHI:-,Multi-Hazard Index,Index describing prevalence of multiple hazards.,MHI,-,universal
+HI:-,Hazard Index,Index describing the level or classification of a hazard or multiple hazards.,HI,-,universal
 EvYr:events/year,Event Frequency - Count per Year,Number of events in a year,EvYr,events/year,universal


### PR DESCRIPTION
Changing MHI to HI, to enable index to be used with single hazard or multiple hazards as defined in hazard type list.
https://github.com/GFDRR/rdl-standard/issues/375