### PR TITLE
schema: Add anyOfs for either/or required fields

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,7 +6,9 @@ This page lists changes to the Risk Data Library Standard.
 
 ### Schema
 
-- [#396](https://github.com/GFDRR/rdl-standard/pull/396) - Require any of `Entity.email`, `Entity.url`.
+- [#396](https://github.com/GFDRR/rdl-standard/pull/396)
+  - `Entity`: Require any of `.email`, `.url`.
+  - `Event.ocurrence`: Require any of `.probabilistic`, `.empirical`, `.deterministic`.
 
 ### Codelists
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,8 @@ This page lists changes to the Risk Data Library Standard.
 
 ### Schema
 
+- []() - Require any of `Entity.email`, `Entity.url`. 
+
 ### Codelists
 
 - [#381](https://github.com/GFDRR/rdl-standard/pull/381) - Add 'risk_index' to `impact_metric.csv`.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,7 +6,7 @@ This page lists changes to the Risk Data Library Standard.
 
 ### Schema
 
-- []() - Require any of `Entity.email`, `Entity.url`. 
+- [#396](https://github.com/GFDRR/rdl-standard/pull/396) - Require any of `Entity.email`, `Entity.url`.
 
 ### Codelists
 

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -1761,7 +1761,24 @@
               "minProperties": 1
             }
           },
-          "minProperties": 1
+          "minProperties": 1,
+          "anyOf": [
+            {
+              "required": [
+                "probabilistic"
+              ]
+            },
+            {
+              "required": [
+                "empirical"
+              ]
+            },
+            {
+              "required": [
+                "deterministic"
+              ]
+            }
+          ]
         },
         "description": {
           "title": "Description",

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -776,7 +776,19 @@
           "format": "iri"
         }
       },
-      "minProperties": 1
+      "minProperties": 1,
+      "anyOf": [
+        {
+          "required": [
+            "email"
+          ]
+        },
+        {
+          "required": [
+            "url"
+          ]
+        }
+      ]
     },
     "Attribution": {
       "title": "Attribution",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,7 +29,7 @@ validate_array_items_kwargs = {
 }
 
 def validate_metadata_presence_allow_missing(pointer):
-    return 'start/oneOf' in pointer or 'end/oneOf' in pointer or pointer.startswith('/anyOf') or pointer.startswith('/properties/links') or pointer.startswith('/$defs/Entity/anyOf/')
+    return 'start/oneOf' in pointer or 'end/oneOf' in pointer or pointer.startswith('/anyOf') or pointer.startswith('/properties/links') or pointer.startswith('/$defs/Entity/anyOf/') or pointer.startswith('/$defs/Event/properties/occurrence/anyOf/')
 
 validate_metadata_presence_kwargs = {
     'allow_missing': validate_metadata_presence_allow_missing,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,7 +29,7 @@ validate_array_items_kwargs = {
 }
 
 def validate_metadata_presence_allow_missing(pointer):
-    return 'start/oneOf' in pointer or 'end/oneOf' in pointer or pointer.startswith('/anyOf') or pointer.startswith('/properties/links')
+    return 'start/oneOf' in pointer or 'end/oneOf' in pointer or pointer.startswith('/anyOf') or pointer.startswith('/properties/links') or pointer.startswith('/$defs/Entity/anyOf/')
 
 validate_metadata_presence_kwargs = {
     'allow_missing': validate_metadata_presence_allow_missing,


### PR DESCRIPTION
**Related issues**

* https://github.com/GFDRR/rdl-standard/issues/306#issuecomment-3656367046
* https://github.com/GFDRR/rdl-standard/issues/306#issuecomment-3896984209

**Description**

The outcome of the discussion in #306 was to not make any changes to the schema other those explained in the comments above.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

If you added, removed or renamed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`
- [ ] Update the diagrams in `reference/schema/md`
- [ ] Update the JSON files in `examples`

Always:

- [x] Run `./manage.py` pre-commit
- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
