### PR TITLE
schema: Replace `Exposure_item.taxonomy` with `Exposure_item.classifi…

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -55,6 +55,7 @@ This page lists changes to the Risk Data Library Standard.
   - `Event_set.spatial`
 - [#409](https://github.com/GFDRR/rdl-standard/pull/409) - Add `Hazard.classification` and `Classification.title`.
 - [#408](https://github.com/GFDRR/rdl-standard/pull/408) - Make `exposure` an array of `Exposure_items`.
+- [#415](https://github.com/GFDRR/rdl-standard/pull/415) - Replace `Exposure_item.taxonomy` with `Exposure_item.classification`.
 
 ### Codelists
 

--- a/schema/rdls_schema.json
+++ b/schema/rdls_schema.json
@@ -1611,7 +1611,7 @@
         },
         "title": {
           "title": "Title",
-          "description": "A description for the classification code.",
+          "description": "A title for the classification code.",
           "type": "string",
           "minLength": 1
         },
@@ -3283,11 +3283,10 @@
             "development_index"
           ]
         },
-        "taxonomy": {
-          "title": "Exposure taxonomy scheme",
-          "type": "string",
-          "description": "The name of the taxonomy scheme used to create descriptive individual asset feature strings within the dataset.",
-          "minLength": 1
+        "asset_type": {
+          "title": "Asset type",
+          "description": "The type of asset",
+          "$ref": "#/$defs/Classification"
         },
         "metrics": {
           "title": "Exposure metrics",


### PR DESCRIPTION
**Related issues**

* Closes #339

**Description**

Uses `Classification` object per https://github.com/GFDRR/rdl-standard/issues/339#issuecomment-3838657398. The later discussion was just about where to put the fields, not how to name them.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

If you added, removed or renamed a field:

- [ ] Update the `collapse` option of the jsonschema directives for dataset, resource, hazard, exposure, vulnerability and loss on `reference/schema.md`
- [ ] Update the diagrams in `reference/schema/md`
- [ ] Update the JSON files in `examples`

Always:

- [x] Run `./manage.py` pre-commit
- [x] Update the changelog ([style guide](developer_docs.md#changelog-style-guide))

**Having trouble?**

See [how to resolve check failures](https://github.com/GFDRR/rdl-standard/blob/dev/developer_docs.md#resolve-check-failures).
