### PR TITLE
Install pre-commit hooks as part of development environment set up

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -12,5 +12,6 @@
     }
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
-  "workspaceFolder": "/workspace"
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "pre-commit install && pre-commit install-hooks"
 }

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -11,6 +11,5 @@ RUN dpkg-reconfigure --frontend=noninteractive locales
 
 COPY requirements.txt /workspace/
 RUN pip3 install --user -r /workspace/requirements.txt
-RUN pre-commit install
 
 CMD ["bash"]

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -11,5 +11,6 @@ RUN dpkg-reconfigure --frontend=noninteractive locales
 
 COPY requirements.txt /workspace/
 RUN pip3 install --user -r /workspace/requirements.txt
+RUN pre-commit install
 
 CMD ["bash"]


### PR DESCRIPTION
Install [pre-commit hooks](https://github.com/GFDRR/rdl-standard/wiki/Reference#pre-commit-hooks) as part of development environment set up.

Previously, these had to be installed manually.

This will help avoid the Markdown linting errors seen in, e.g. https://github.com/GFDRR/rdl-standard/pull/453

No changelog entry required as not related to the standard itself.

I'll merge directly since this is a minor change to the dev container config.